### PR TITLE
Fix 2018 results link, previously gave a 404

### DIFF
--- a/2018/index.html
+++ b/2018/index.html
@@ -85,7 +85,7 @@
             <h3 class="desc">The premier west-coast Science Olympiad invitational, hosted by Stanford and UC Berkeley students.</h3>
             <h3 class="desc">January 27th, 2018</h3>
             <br>
-            <a href="/doc/results.pdf" class="btn btn-xlg btn-light">Final Results</a>
+            <a href="./doc/results.pdf" class="btn btn-xlg btn-light">Final Results</a>
             <!--<a href="/registration" class="btn btn-xlg btn-dark desc">Register</a>
             <a href="http://eepurl.com/b0-fnr" class="btn btn-xlg btn-dark desc">Sign up for updates</a>-->
 


### PR DESCRIPTION
There are other absolute links in the archives that probably should be
relative links, but this is the most visible one in terms of reasons why
users might want to visit the Past Tournaments tab (to see past results).